### PR TITLE
[feat] Implement 'AddChartRepo'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY      ?= tmaxcloudck
 VERSION       ?= 0.0.1
 
-HS_IMG   = $(REGISTRY)/template-validating-webhook:$(VERSION)
+HS_IMG   = $(REGISTRY)/helm-server:$(VERSION)
 
 .PHONY: test build push
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,29 +5,34 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	helmclient "github.com/mittwald/go-helm-client"
+	"github.com/tmax-cloud/helm-apiserver/internal"
 	"github.com/tmax-cloud/helm-apiserver/pkg/apis"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
 	releasePrefix = "/release"
 	chartPrefix   = "/chart"
+
+	repositoryCache  = "/tmp/.helmcache" // 캐시 디렉토리. 특정 chart-repo에 해당하는 chart 이름 리스트 txt파일과, 해당 repo의 index.yaml 파일이 저장됨
+	repositoryConfig = "/tmp/.helmrepo"  // 현재 add된 repo들 저장. go helm client 버그. 무조건 /tmp/.helmrepo 에다가 저장됨.
 )
 
 func main() {
 	klog.Infoln("initializing server....")
-
 	router := mux.NewRouter()
 
-	// c, err := internal.Client(client.Options{})
-	// if err != nil {
-	// 	panic(err)
-	// }
+	// Create HelmClientManager
+	hcm := apis.HelmClientManager{Hc: newHelmClient()}
 
-	router.HandleFunc(releasePrefix, apis.InstallRelease).Methods("POST", "PUT")
-	router.HandleFunc(releasePrefix, apis.UnInstallRelease).Methods("DELETE")
-	router.HandleFunc(releasePrefix, apis.RollbackRelease).Methods("PATCH")
-	router.HandleFunc(chartPrefix, apis.AddChartRepo).Methods("GET")
+	router.HandleFunc(releasePrefix, hcm.InstallRelease).Methods("POST", "PUT")
+	router.HandleFunc(releasePrefix, hcm.UnInstallRelease).Methods("DELETE")
+	router.HandleFunc(releasePrefix, hcm.RollbackRelease).Methods("PATCH")
+	router.HandleFunc(chartPrefix, hcm.AddChartRepo).Methods("POST")
 
 	http.Handle("/", router)
 
@@ -35,4 +40,40 @@ func main() {
 		klog.Errorln(err, "failed to initialize a server")
 	}
 
+}
+
+func newHelmClient() helmclient.Client {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		klog.Errorln(err, "failed to get rest config")
+	}
+
+	c, _ := client.New(cfg, client.Options{})
+
+	sa, _ := internal.GetServiceAccount(c, types.NamespacedName{Name: "helm-server-sa", Namespace: "helm-ns"})
+	var secretName string
+
+	for _, sec := range sa.Secrets {
+		secretName = sec.Name
+	}
+
+	testSecret, _ := internal.GetSecret(c, types.NamespacedName{Name: secretName, Namespace: "helm-ns"})
+	token := testSecret.Data["token"]
+
+	opt := &helmclient.Options{
+		RepositoryCache:  repositoryCache,
+		RepositoryConfig: repositoryConfig,
+		Debug:            true,
+		Linting:          true,
+	}
+
+	cfg.BearerToken = string(token)
+	cfg.BearerTokenFile = ""
+
+	helmClient, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{Options: opt, RestConfig: cfg})
+	if err != nil {
+		klog.Errorln(err, "failed to create helm client")
+	}
+
+	return helmClient
 }

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-server
+  namespace: helm-ns
+  labels:
+    app: helm-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helm-server
+  template:
+    metadata:
+      labels:
+        app: helm-server
+    spec:
+      serviceAccountName: helm-server-sa
+      containers:
+      - name: helm-server
+        image: 172.22.11.2:30500/helm-server:yjh # TODO : 수정 필요
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: helm-server-data
+            mountPath: /tmp # .helmrepo 버그 때문에 임시 경로 지정
+      volumes:
+        - name: helm-server-data
+          persistentVolumeClaim:
+            claimName: helm-server-pvc

--- a/deploy/pvc.yaml
+++ b/deploy/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: helm-server-pvc
+  namespace: helm-ns
+spec:
+  resources:
+    requests:
+      storage: 1Gi # 임시
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce # 임시. 바꿔줘야함.
+  storageClassName: "local-path" # 임시. 환경 스토리지클래스 확인할 것

--- a/pkg/apis/helm_client_manager.go
+++ b/pkg/apis/helm_client_manager.go
@@ -1,0 +1,7 @@
+package apis
+
+import helmclient "github.com/mittwald/go-helm-client"
+
+type HelmClientManager struct {
+	Hc helmclient.Client
+}

--- a/pkg/apis/install.go
+++ b/pkg/apis/install.go
@@ -5,55 +5,18 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/tmax-cloud/helm-apiserver/internal"
 	"github.com/tmax-cloud/helm-apiserver/pkg/schemas"
 	"k8s.io/klog"
-
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	helmclient "github.com/mittwald/go-helm-client"
 )
 
-func InstallRelease(w http.ResponseWriter, r *http.Request) {
-
+func (hcm *HelmClientManager) InstallRelease(w http.ResponseWriter, r *http.Request) {
+	klog.Infoln("InstallRelease")
 	req := schemas.ReleaseRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		klog.Errorln(err, "failed to decode request")
 		return
-	}
-
-	cfg, err := config.GetConfig()
-	if err != nil {
-		klog.Errorln(err, "failed to get rest config")
-	}
-
-	c, _ := client.New(cfg, client.Options{})
-
-	sa, _ := internal.GetServiceAccount(c, types.NamespacedName{Name: "helm-server-test-sa", Namespace: "helm-ns"})
-	var secretName string
-
-	for _, sec := range sa.Secrets {
-		secretName = sec.Name
-	}
-
-	testSecret, _ := internal.GetSecret(c, types.NamespacedName{Name: secretName, Namespace: "helm-ns"})
-	token := testSecret.Data["token"]
-
-	opt := &helmclient.Options{
-		RepositoryCache:  "/tmp/.helmcache",
-		RepositoryConfig: "/tmp/.helmrepo",
-		Debug:            true,
-		Linting:          true,
-	}
-
-	cfg.BearerToken = string(token)
-	cfg.BearerTokenFile = ""
-
-	helmClient, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{Options: opt, RestConfig: cfg})
-	if err != nil {
-		klog.Errorln(err, "failed to create helm client")
 	}
 
 	chartSpec := helmclient.ChartSpec{
@@ -67,7 +30,7 @@ func InstallRelease(w http.ResponseWriter, r *http.Request) {
 		Wait:        false,
 	}
 
-	if _, err := helmClient.InstallOrUpgradeChart(context.Background(), &chartSpec); err != nil {
+	if _, err := hcm.Hc.InstallOrUpgradeChart(context.Background(), &chartSpec); err != nil {
 		klog.Errorln(err, "failed to install chart")
 	}
 

--- a/pkg/apis/rollback.go
+++ b/pkg/apis/rollback.go
@@ -4,56 +4,19 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/tmax-cloud/helm-apiserver/internal"
 	"github.com/tmax-cloud/helm-apiserver/pkg/schemas"
 
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	helmclient "github.com/mittwald/go-helm-client"
 )
 
-func RollbackRelease(w http.ResponseWriter, r *http.Request) {
-
+func (hcm *HelmClientManager) RollbackRelease(w http.ResponseWriter, r *http.Request) {
+	klog.Infoln("RollbackRelease")
 	req := schemas.ReleaseRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		klog.Errorln(err, "failed to decode request")
 		return
-	}
-
-	cfg, err := config.GetConfig()
-	if err != nil {
-		klog.Errorln(err, "failed to get rest config")
-	}
-
-	c, _ := client.New(cfg, client.Options{})
-
-	sa, _ := internal.GetServiceAccount(c, types.NamespacedName{Name: "helm-server-test-sa", Namespace: "helm-ns"})
-	var secretName string
-
-	for _, sec := range sa.Secrets {
-		secretName = sec.Name
-	}
-
-	testSecret, _ := internal.GetSecret(c, types.NamespacedName{Name: secretName, Namespace: "helm-ns"})
-	token := testSecret.Data["token"]
-
-	opt := &helmclient.Options{
-		RepositoryCache:  "/tmp/.helmcache",
-		RepositoryConfig: "/tmp/.helmrepo",
-		Debug:            true,
-		Linting:          true,
-	}
-
-	cfg.BearerToken = string(token)
-	cfg.BearerTokenFile = ""
-
-	helmClient, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{Options: opt, RestConfig: cfg})
-	if err != nil {
-		klog.Errorln(err, "failed to create helm client")
-
 	}
 
 	chartSpec := helmclient.ChartSpec{
@@ -66,7 +29,7 @@ func RollbackRelease(w http.ResponseWriter, r *http.Request) {
 		Wait:        false,
 	}
 
-	if err := helmClient.RollbackRelease(&chartSpec, 0); err != nil {
+	if err := hcm.Hc.RollbackRelease(&chartSpec, 0); err != nil {
 		klog.Errorln(err, "failed to rollback chart")
 	}
 

--- a/pkg/apis/uninstall.go
+++ b/pkg/apis/uninstall.go
@@ -4,55 +4,19 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/tmax-cloud/helm-apiserver/internal"
 	"github.com/tmax-cloud/helm-apiserver/pkg/schemas"
 
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	helmclient "github.com/mittwald/go-helm-client"
 )
 
-func UnInstallRelease(w http.ResponseWriter, r *http.Request) {
-
+func (hcm *HelmClientManager) UnInstallRelease(w http.ResponseWriter, r *http.Request) {
+	klog.Infoln("UnInstallRelease")
 	req := schemas.ReleaseRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		klog.Errorln(err, "failed to decode request")
 		return
-	}
-
-	cfg, err := config.GetConfig()
-	if err != nil {
-		klog.Errorln(err, "failed to get rest config")
-	}
-
-	c, _ := client.New(cfg, client.Options{})
-
-	sa, _ := internal.GetServiceAccount(c, types.NamespacedName{Name: "helm-server-test-sa", Namespace: "helm-ns"})
-	var secretName string
-
-	for _, sec := range sa.Secrets {
-		secretName = sec.Name
-	}
-
-	testSecret, _ := internal.GetSecret(c, types.NamespacedName{Name: secretName, Namespace: "helm-ns"})
-	token := testSecret.Data["token"]
-
-	opt := &helmclient.Options{
-		RepositoryCache:  "/tmp/.helmcache",
-		RepositoryConfig: "/tmp/.helmrepo",
-		Debug:            true,
-		Linting:          true,
-	}
-
-	cfg.BearerToken = string(token)
-	cfg.BearerTokenFile = ""
-
-	helmClient, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{Options: opt, RestConfig: cfg})
-	if err != nil {
-		klog.Errorln(err, "failed to create helm client")
 	}
 
 	chartSpec := helmclient.ChartSpec{
@@ -65,7 +29,7 @@ func UnInstallRelease(w http.ResponseWriter, r *http.Request) {
 		Wait:        false,
 	}
 
-	if err := helmClient.UninstallRelease(&chartSpec); err != nil {
+	if err := hcm.Hc.UninstallRelease(&chartSpec); err != nil {
 		klog.Errorln(err, "failed to uninstall chart")
 	}
 


### PR DESCRIPTION
- PVC 통해 서버 스토리지 구축 (.helmcache, .helmrepo가 저장됨)
- 각 api 별로 실행되던 helmClient 생성하는 로직을 함수로 리팩토링
- 각 api를 helmClientManager 객체 메소드로 귀속 (helmClient를 공유하기 위해)